### PR TITLE
API deprecations in 1.16

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "helm-fluentd-kinesis-firehose.fullname" . }}
@@ -12,6 +12,9 @@ metadata:
     version: v1
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-logging
   template:
     metadata:
       labels:


### PR DESCRIPTION
There has been some changes in API, please see following link
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/